### PR TITLE
pip installs requirements for the default python which is 2.6 or 2.4 @ uberspace.de

### DIFF
--- a/flask-uberspace-quickstart.fcgi
+++ b/flask-uberspace-quickstart.fcgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # This is the path relative to /
 # If your application is available at www.domain.com/subdir/subdir2/myapplication this should be /subdir/subdir2/myapplication


### PR DESCRIPTION
see: http://uberspace.de/dokuwiki/development:python
and: https://github.com/JonasGroeger/flask-uberspace-quickstart/blob/master/README.md
